### PR TITLE
fix the link in the navbar to anchors of index

### DIFF
--- a/_data/nav_zh-CN.yml
+++ b/_data/nav_zh-CN.yml
@@ -6,11 +6,11 @@
   title: 活动资讯
 # - href: "/#gues"
 #   title: 招待講演者
-# - href: "/index_en.html#schedule"
+# - href: "/index_zh-cn.html#schedule"
 #   title: Schedule
-# - href: "/index_en.html#tickets"
+# - href: "/index_zh-cn.html#tickets"
 #   title: Tickets
-- href: "/index_en.html#sp"
+- href: "/index_zh-cn.html#sp"
   title: Sponsors
 # - href: "/en/commercial"
 #   title: CM

--- a/_data/nav_zh-TW.yml
+++ b/_data/nav_zh-TW.yml
@@ -6,11 +6,11 @@
   title: 活動資訊
 # - href: "/#gues"
 #   title: 招待講演者
-# - href: "/index_en.html#schedule"
+# - href: "/index_zh-tw.html#schedule"
 #   title: Schedule
-# - href: "/index_en.html#tickets"
+# - href: "/index_zh-tw.html#tickets"
 #   title: Tickets
-- href: "/index_en.html#sp"
+- href: "/index_zh-tw.html#sp"
   title: Sponsors
 # - href: "/en/commercial"
 #   title: CM


### PR DESCRIPTION
navbarのリンクにまだ英語版に向いているものがあるので、
中国語版に向けておきます

但し、indexのみの対応です。
それ以外のページへのリンクは、基本的に英語版へと向けておき
具体的に中国語対応が済んだ場合に中国語版へと向き先を変えることとします。