### PR TITLE
スポンサーロゴのBackgroundに明示的に色を指定するように修正

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -202,7 +202,8 @@ input, select {
 }
 
 .logoArea ul li img{
-	width:100%;
+  width:100%;
+  background-color: #fff;
 }
 
 .logoArea h2 img{
@@ -555,8 +556,9 @@ input, select {
 }
 
 .sectionStyle7Inner ul li img{
-	width:100%;
-	border:1px solid #dedede;
+  width:100%;
+  border:1px solid #dedede;
+  background-color: #fff;
 }
 
 .sectionStyle7Inner ul{


### PR DESCRIPTION
## 概要
* 背景色が透過のスポンサーロゴでも問題なく表示できる用に、明示的に背景色を指定した

## その他
* もうちょっとCSSは整理したい（がCSS力が足りない）
