### PR TITLE
一部デザイン崩れの修正

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -523,19 +523,13 @@ input, select {
 }
 
 .sectionStyle7Inner .ttlspBox1{
-	width:862px;
+	width:100%;
 	margin:0 auto 0 auto;
-}
-
-.sectionStyle7Inner .ttlspBox1{
 	background:#d30101;
 	color:#fff;
 	text-align:center;
 	padding-top:10px;
 	padding-bottom:10px;
-}
-
-.sectionStyle7Inner .ttlspBox1{
 	margin-bottom:20px;
 }
 
@@ -891,10 +885,6 @@ h1.session_title {
 
 
 	.sectionStyle7Inner{
-		width:100%;
-	}
-
-	.sectionStyle7Inner .ttlspBox1{
 		width:100%;
 	}
 

--- a/css/common.css
+++ b/css/common.css
@@ -942,55 +942,56 @@ h1.session_title {
 
 @media screen and (max-width: 700px){
 
-	.logoArea{
-		padding-top:100px;
-		padding-bottom:80px;
-	}
+  .logoArea{
+    width: 100%;
+  }
+
+  .sectionStyle3 .sectionHeadArea{
+    width:100%;
+  }
 }
 
 @media screen and (max-width: 560px){
 
-		.mainVisInner h1 img{
-			width:90%;
-		}
+  .logoArea{
+    width: 100%;
+  }
 
-		.sectionStyle5 h2{
-			position: relative;
-			height:76px;
-		}
+	.mainVisInner h1 img{
+		width:90%;
+	}
 
-		.sectionTicket h2{
-			position: relative;
-			height:76px;
-		}
+	.sectionStyle5 h2{
+		position: relative;
+		height:76px;
+	}
 
-		.sectionStyle5 .sectionHeadArea .ttlSubLLeft{
-			width:12%;
-		}
+	.sectionTicket h2{
+		position: relative;
+		height:76px;
+	}
 
-		.sectionStyle5 .sectionHeadArea .ttlSubLLeft img{
-			width:100%;
-		}
+	.sectionStyle5 .sectionHeadArea .ttlSubLLeft{
+		width:12%;
+	}
 
-		.sectionStyle5 .sectionHeadArea .ttlSubLRight{
-			width:12%;
-		}
+	.sectionStyle5 .sectionHeadArea .ttlSubLLeft img{
+		width:100%;
+	}
 
-		.sectionStyle5 .sectionHeadArea .ttlSubLRight img{
-			width:100%;
-		}
+	.sectionStyle5 .sectionHeadArea .ttlSubLRight{
+		width:12%;
+	}
 
-		.sectionStyle5 .sectionHeadArea .ttlSubLCenter{
-			width:66%;
-			left:50%;
-			margin-left:-33%;
-		}
+	.sectionStyle5 .sectionHeadArea .ttlSubLRight img{
+		width:100%;
+	}
 
-
-		.sectionStyle3 .sectionHeadArea{
-			width:100%;
-		}
-
+	.sectionStyle5 .sectionHeadArea .ttlSubLCenter{
+		width:66%;
+		left:50%;
+		margin-left:-33%;
+	}
 }
 
 @media screen and (max-width: 530px){


### PR DESCRIPTION
## 概要
* スポンサーロゴが上の帯よりもはみ出たりしていた部分を修正
* 幅が560-700pxの時に「セッション募集」のレイアウトが崩れていたのを修正

## ScreenShot

### スポンサーロゴ周辺Before

![before](https://user-images.githubusercontent.com/1191278/32989386-4c4fa294-cd58-11e7-8d19-8fa65d38f118.png)


### スポンサーロゴ周辺After

![after](https://user-images.githubusercontent.com/1191278/32989387-521abbe6-cd58-11e7-8e34-860dc69a50dd.png)

### セッション募集の右部分 before

![before2](https://user-images.githubusercontent.com/1191278/32989400-7987c3f4-cd58-11e7-910e-acf16a440bec.png)

### セッション募集の右部分 after

![after2](https://user-images.githubusercontent.com/1191278/32989403-815357b0-cd58-11e7-972d-a4c9f5caf73a.png)
