### PR TITLE
"末尾のカンマ" が導入されたのは2.12.1ではなく2.12.2から

### DIFF
--- a/_candidates_ja/DaleWijnand_3.md
+++ b/_candidates_ja/DaleWijnand_3.md
@@ -1,6 +1,6 @@
 ---
 name: Dale Wijnand
-title: "Scala 2.12.1でサポートされた末尾のカンマにどうやって至ったのか？"
+title: "Scala 2.12.2でサポートされた末尾のカンマにどうやって至ったのか？"
 length: 10
 audience: Intermediate
 language: English


### PR DESCRIPTION
原文もそうなっている。

以下実際に試した例

```
Welcome to Scala 2.12.1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_151).
Type in expressions for evaluation. Or try :help.

scala> def foo(
     |   a: Int,
     | ) = a
<console>:3: error: identifier expected but ')' found.
) = a
^
```

```
Welcome to Scala 2.12.2 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_151).
Type in expressions for evaluation. Or try :help.

scala> def foo(
     |   a: Int,
     | ) = a
foo: (a: Int)Int
```