### PR TITLE
translate Tickets and Sponsors section into Chinese

### DIFF
--- a/_data/nav_zh-CN.yml
+++ b/_data/nav_zh-CN.yml
@@ -8,8 +8,8 @@
 #   title: 招待講演者
 # - href: "/index_zh-cn.html#schedule"
 #   title: Schedule
-# - href: "/index_zh-cn.html#tickets"
-#   title: Tickets
+- href: "/index_zh-cn.html#tickets"
+  title: 票务资讯
 - href: "/index_zh-cn.html#sp"
   title: Sponsors
 # - href: "/en/commercial"

--- a/_data/nav_zh-TW.yml
+++ b/_data/nav_zh-TW.yml
@@ -8,8 +8,8 @@
 #   title: 招待講演者
 # - href: "/index_zh-tw.html#schedule"
 #   title: Schedule
-# - href: "/index_zh-tw.html#tickets"
-#   title: Tickets
+- href: "/index_zh-tw.html#tickets"
+  title: 票務資訊
 - href: "/index_zh-tw.html#sp"
   title: Sponsors
 # - href: "/en/commercial"

--- a/_includes/ticket_zh-cn.html
+++ b/_includes/ticket_zh-cn.html
@@ -5,6 +5,7 @@
       <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
       <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
     </h2>
+    <p class="subTtlSm">Tickets</p>
   </header>
   <div class="sectionTicketInner">
     <div class="txtBlock">

--- a/_includes/ticket_zh-cn.html
+++ b/_includes/ticket_zh-cn.html
@@ -1,7 +1,7 @@
 <section class="sectionTicket" id="tickets">
   <header class="sectionHeadArea">
     <h2 class="clearfix">
-      <span class="ttlSubLCenter">Tickets</span>
+      <span class="ttlSubLCenter">票务资讯</span>
       <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
       <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
     </h2>
@@ -9,10 +9,10 @@
   <div class="sectionTicketInner">
     <div class="txtBlock">
       <p>
-        Registration fees are required to participate in the conference.
+        参加活动需要门票。
       </p>
       <p>
-        Please purchase the tickets from Doorkeeper.
+        购票及相关资讯请利用下方网站。
       </p>
     </div>
     <p>

--- a/_includes/ticket_zh-tw.html
+++ b/_includes/ticket_zh-tw.html
@@ -1,7 +1,7 @@
 <section class="sectionTicket" id="tickets">
   <header class="sectionHeadArea">
     <h2 class="clearfix">
-      <span class="ttlSubLCenter">Tickets</span>
+      <span class="ttlSubLCenter">票務資訊</span>
       <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
       <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
     </h2>
@@ -9,10 +9,10 @@
   <div class="sectionTicketInner">
     <div class="txtBlock">
       <p>
-        Registration fees are required to participate in the conference.
+        參加活動需要門票。
       </p>
       <p>
-        Please purchase the tickets from Doorkeeper.
+        購票及相關資訊請利用下方網站。
       </p>
     </div>
     <p>

--- a/_includes/ticket_zh-tw.html
+++ b/_includes/ticket_zh-tw.html
@@ -5,6 +5,7 @@
       <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
       <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
     </h2>
+    <p class="subTtlSm">Tickets</p>
   </header>
   <div class="sectionTicketInner">
     <div class="txtBlock">

--- a/index_zh-cn.html
+++ b/index_zh-cn.html
@@ -155,7 +155,7 @@ layout: null
 				<p>※ 16日为 Scala 的学习体验讨论会（仅日语），17～18日为各种正式及非正式演讲（日语、英语）</p>
 				<div class="logoArea">
           <h2 class="clearfix">
-            <span class="ttlSpAreaTop">Shogun sponsor</span>
+            <span class="ttlSpAreaTop">将军 sponsor</span>
             <span class="linelSpAreaTop"><img src="img/common/ttl_main_line.png" alt="" /></span>
             <span class="linerSpAreaTop"><img src="img/common/ttl_main_line.png" alt="" /></span>
           </h2>
@@ -337,13 +337,13 @@ layout: null
           <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
           <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
         </h2>
-        <p class="subTtlSm">Sponsor</p>
+        <p class="subTtlSm"></p>
       </header>
 
       <div class="sectionStyle7Inner">
 
         <article class="spBox">
-          <h3 class="ttlspBox1">Shogun sponsor</h3>
+          <h3 class="ttlspBox1">将军 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.shogun %}
             <li class="shogunLogo">
@@ -354,7 +354,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv2">Tairo sponsor</h3>
+          <h3 class="ttlspBox1 spLv2">大老 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.tairo %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -363,7 +363,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv3">Daimyo sponsor</h3>
+          <h3 class="ttlspBox1 spLv3">大名 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.daimyo %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -372,7 +372,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv4">Samurai sponsor</h3>
+          <h3 class="ttlspBox1 spLv4">侍 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.samurai %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -381,7 +381,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv5">Ninja sponsor</h3>
+          <h3 class="ttlspBox1 spLv5">忍者 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.ninja %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -390,7 +390,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv6">Bugyo sponsor</h3>
+          <h3 class="ttlspBox1 spLv6">协力奉行</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.bugyo %}
             <li>

--- a/index_zh-tw.html
+++ b/index_zh-tw.html
@@ -155,7 +155,7 @@ layout: null
 				<p>※ 16日爲Scala的學習體驗討論會（僅日語），17～18日爲各種正式及非正式演講（日語、英語）</p>
 				<div class="logoArea">
           <h2 class="clearfix">
-            <span class="ttlSpAreaTop">Shogun sponsor</span>
+            <span class="ttlSpAreaTop">將軍 sponsor</span>
             <span class="linelSpAreaTop"><img src="img/common/ttl_main_line.png" alt="" /></span>
             <span class="linerSpAreaTop"><img src="img/common/ttl_main_line.png" alt="" /></span>
           </h2>
@@ -337,13 +337,13 @@ layout: null
           <span class="ttlSubLLeft"><img src="img/common/ttl_dots_left.png"></span>
           <span class="ttlSubLRight"><img src="img/common/ttl_dots_right.png"></span>
         </h2>
-        <p class="subTtlSm">Sponsor</p>
+        <p class="subTtlSm"></p>
       </header>
 
       <div class="sectionStyle7Inner">
 
         <article class="spBox">
-          <h3 class="ttlspBox1">Shogun sponsor</h3>
+          <h3 class="ttlspBox1">將軍 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.shogun %}
             <li class="shogunLogo">
@@ -354,7 +354,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv2">Tairo sponsor</h3>
+          <h3 class="ttlspBox1 spLv2">大老 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.tairo %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -363,7 +363,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv3">Daimyo sponsor</h3>
+          <h3 class="ttlspBox1 spLv3">大名 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.daimyo %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -372,7 +372,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv4">Samurai sponsor</h3>
+          <h3 class="ttlspBox1 spLv4">侍 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.samurai %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -381,7 +381,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv5">Ninja sponsor</h3>
+          <h3 class="ttlspBox1 spLv5">忍者 sponsor</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.ninja %}
             <li><a href="{{ logo.href }}"><img src="{{ logo.img }}" alt="{{ logo.title }}" /></a></li>
@@ -390,7 +390,7 @@ layout: null
         </article>
 
         <article class="spBox">
-          <h3 class="ttlspBox1 spLv6">Bugyo sponsor</h3>
+          <h3 class="ttlspBox1 spLv6">協力奉行</h3>
           <ul class="clearfix shuffle">
             {% for logo in site.data.logos.bugyo %}
             <li>


### PR DESCRIPTION
## Overview

- language
  - Simplified Chinese
  - Traditional Chinese
- target
  - the link in the menu bar
  - the section for shogun sponsor logos below the main visual
  -  Tickets section
  - Sponsors section

## 简体中文

- menu
  - 
![screen shot 2017-12-23 at 12 16 44](https://user-images.githubusercontent.com/2375792/34316574-a36d0ece-e7dc-11e7-877a-429696b2ca9f.png)
- Shogun sponsors
  - 
![screen shot 2017-12-23 at 12 17 39](https://user-images.githubusercontent.com/2375792/34316575-adbe35ce-e7dc-11e7-8a5d-f451b65da236.png)

- Tickets section
  - 
![screen shot 2017-12-23 at 12 16 58](https://user-images.githubusercontent.com/2375792/34316576-b48be89c-e7dc-11e7-9c71-449599e1f5c0.png)

- Sponsors section
  - 
![screen shot 2017-12-23 at 12 17 09](https://user-images.githubusercontent.com/2375792/34316578-b89a9bcc-e7dc-11e7-8871-1e39afd5af08.png)


## 繁體中文

- menu
  - 
![screen shot 2017-12-23 at 12 17 27](https://user-images.githubusercontent.com/2375792/34316583-c5c5aa12-e7dc-11e7-9851-deda01dcf8cd.png)

- Shogun sponsors
  - 
![screen shot 2017-12-23 at 12 17 48](https://user-images.githubusercontent.com/2375792/34316584-d1cba1ea-e7dc-11e7-8897-e8039abbe99b.png)


- Tickets section
  - 
![screen shot 2017-12-23 at 12 17 54](https://user-images.githubusercontent.com/2375792/34316585-d612c40e-e7dc-11e7-9dca-aa5000fb5c82.png)

- Sponsors section
  - 
![screen shot 2017-12-23 at 12 18 00](https://user-images.githubusercontent.com/2375792/34316586-d940d454-e7dc-11e7-81ed-60a3bc2844fa.png)


