### PR TITLE
time tableのLayout(表示)修正

### DIFF
--- a/_includes/program/day1.html
+++ b/_includes/program/day1.html
@@ -226,7 +226,7 @@
     <tr>
       <th>{{ day1.slots[22].time }}</th>
       <td colspan="3">
-        <p>{{ day1.slots[22].rooms.a.title }}</p>
+        {{ day1.slots[22].rooms.a.title }}
       </td>
     </tr>
   </table>

--- a/_includes/program/slot.html
+++ b/_includes/program/slot.html
@@ -1,7 +1,5 @@
 {% assign title = include.title  %}
 {% assign speaker = include.speaker  %}
 
-<p>
-  {{ title }}
-  {% if speaker.size > 0 %}&nbsp;-&nbsp;{{ speaker }}{% endif %}
-</p>
+{{ title }}
+{% if speaker.size > 0 %}&nbsp;-&nbsp;{{ speaker }}{% endif %}


### PR DESCRIPTION
### 概要

| before | after |
|:--:|:--:|
|![before1](https://user-images.githubusercontent.com/1191278/36932058-e4b91092-1f06-11e8-9c01-e1b735a48430.png)|![after1](https://user-images.githubusercontent.com/1191278/36932065-02502046-1f07-11e8-9fb7-8d37fe67c7b3.png)|
|![before2](https://user-images.githubusercontent.com/1191278/36932071-227e1ce2-1f07-11e8-869d-f4b235fcf757.png)|![after2](https://user-images.githubusercontent.com/1191278/36932075-28d940f8-1f07-11e8-9d35-b78defda2322.png)|
|![before3](https://user-images.githubusercontent.com/1191278/36932085-49abcddc-1f07-11e8-848c-5c45446391e1.png)|![after3](https://user-images.githubusercontent.com/1191278/36932089-5098d31a-1f07-11e8-8b16-1b74e993ad15.png)|


不要なpタグを削除しただけですが、見栄えは良くなったと思います


