### PR TITLE
開催概要部分の文言位置修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,16 +190,13 @@ layout: null
 					<p class="subTtlSm">Event Info</p>
 				</header>
 				<div class="contArea">
-					<p>
-						また、<a href="https://twitter.com/scala_jp">twitter</a>や<a href="https://www.facebook.com/ScalaMatsuri">facebook</a>でも随時情報を発信していますので、是非フォロー/いいねをお願いします。
-					</p>
-					<table>
+					<table style="margin-bottom: 2em;">
 						<tr>
 							<th>日程</th>
 							<td>
 								2018年3月16日(金)、3月17日(土)、3月18日(日)<br/>
-								※ 16日は日本語でのトレーニングDay、17~18日は日本語/英語でのカンファレンスとアンカンファレンスが開催されます。
-                <a href="/ja/unconference">アンカンファレンスとは？</a>
+								※ 16日は日本語でのトレーニングDay、17~18日は日本語/英語でのカンファレンスと<a href="/ja/unconference">アンカンファレンス</a>が開催されます。<br/>
+                ※ <a href="/ja/unconference">アンカンファレンスについてはこちら</a>
 							</td>
 						</tr>
 						<tr>
@@ -214,11 +211,14 @@ layout: null
             <tr>
               <th>チケット</th>
               <td>
-                参加にはチケットが必要です。<a href='https://scalaconfjp.doorkeeper.jp/events/{{ site.doorkeeper.event.id }}'>こちら</a>からご購入下さい、。
+                参加にはチケットが必要です。<a href='https://scalaconfjp.doorkeeper.jp/events/{{ site.doorkeeper.event.id }}'>こちら</a>からご購入下さい。
               </td>
             </tr>
 
 					</table>
+					<p>
+						<a href="https://twitter.com/scala_jp">twitter</a>や<a href="https://www.facebook.com/ScalaMatsuri">facebook</a>でも随時情報を発信していますので、是非フォロー/いいねをお願いします。
+					</p>
 				</div>
 			</div>
 		</section>

--- a/index_en.html
+++ b/index_en.html
@@ -190,18 +190,12 @@ layout: null
           <p class="subTtlSm"></p>
 				</header>
 				<div class="contArea">
-					<!--
-					<p>Scala に関する海外からのゲストスピーカーも招いた大規模な有料イベントです。 パラレルに 2 セッションで進行する予定です。一般募集のセッションや LT 大会も行う予定です。 懇親会についても行う予定ですが、現在調整中です。</p>
-					-->
-					<p>
-						We announce the news at <a href="https://twitter.com/scala_jp">twitter</a> and <a href="https://www.facebook.com/ScalaMatsuri">facebook</a>.Please follow/like.
-					</p>
-					<table>
+					<table style="margin-bottom: 2em;">
 						<tr>
 							<th>Dates</th>
 							<td>
 								16th(Fri.) - 18th(Sun.) March in 2018<br/>
-								Note: Conference and unconference in English/Japanese will be on 17th-18th March. Trainings in Japanese will be on 16th March.
+								Note: Conference and <a href="/ja/unconference">unconference</a> in English/Japanese will be on 17th-18th March. Trainings in Japanese will be on 16th March.<br/>
                 <a href="/ja/unconference">What is unconference?</a>
               </td>
 						</tr>
@@ -220,6 +214,9 @@ layout: null
               </td>
 						</tr>
 					</table>
+					<p>
+						We announce the news at <a href="https://twitter.com/scala_jp">twitter</a> and <a href="https://www.facebook.com/ScalaMatsuri">facebook</a>.Please follow/like.
+					</p>
 				</div>
 			</div>
 		</section>

--- a/index_zh-cn.html
+++ b/index_zh-cn.html
@@ -191,13 +191,7 @@ layout: null
           <p class="subTtlSm">Event Info</p>
 				</header>
 				<div class="contArea">
-					<!--
-					<p>Scala に関する海外からのゲストスピーカーも招いた大規模な有料イベントです。 パラレルに 2 セッションで進行する予定です。一般募集のセッションや LT 大会も行う予定です。 懇親会についても行う予定ですが、現在調整中です。</p>
-					-->
-					<p>
-						相关资讯会在 <a href="https://twitter.com/scala_jp">twitter</a> 及 <a href="https://www.facebook.com/ScalaMatsuri">facebook</a> 陆续发布，请随时关注。
-					</p>
-					<table>
+					<table style="margin-bottom: 2em;">
 						<tr>
 							<th>日期</th>
 							<td>
@@ -221,6 +215,9 @@ layout: null
               </td>
             </tr>
 					</table>
+					<p>
+						相关资讯会在 <a href="https://twitter.com/scala_jp">twitter</a> 及 <a href="https://www.facebook.com/ScalaMatsuri">facebook</a> 陆续发布，请随时关注。
+					</p>
 				</div>
 			</div>
 		</section>

--- a/index_zh-tw.html
+++ b/index_zh-tw.html
@@ -191,13 +191,7 @@ layout: null
           <p class="subTtlSm">Event Info</p>
 				</header>
 				<div class="contArea">
-					<!--
-					<p>Scala に関する海外からのゲストスピーカーも招いた大規模な有料イベントです。 パラレルに 2 セッションで進行する予定です。一般募集のセッションや LT 大会も行う予定です。 懇親会についても行う予定ですが、現在調整中です。</p>
-					-->
-					<p>
-						相關資訊會在 <a href="https://twitter.com/scala_jp">twitter</a> 及 <a href="https://www.facebook.com/ScalaMatsuri">facebook</a> 陸續發布，請隨時關注。
-					</p>
-					<table>
+					<table style="margin-bottom: 2em;">
 						<tr>
 							<th>Dates</th>
 							<td>
@@ -221,6 +215,9 @@ layout: null
               </td>
             </tr>
 					</table>
+					<p>
+						相關資訊會在 <a href="https://twitter.com/scala_jp">twitter</a> 及 <a href="https://www.facebook.com/ScalaMatsuri">facebook</a> 陸續發布，請隨時關注。
+					</p>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
### 概要

before

![before1](https://user-images.githubusercontent.com/1191278/36932109-d5e120cc-1f07-11e8-98b6-07a7cb6f037f.png)


after 

![after1](https://user-images.githubusercontent.com/1191278/36932110-da5a69ce-1f07-11e8-92a1-4157508e2416.png)


* 文言的に「また、」で始まっていた部分を削除
* 開催概要そのものを上に配置